### PR TITLE
.NET 6.0 Support (fixes #7):

### DIFF
--- a/src/Blazor.WebAssembly.Authentication.Auth0/Auth0ProviderOptions.cs
+++ b/src/Blazor.WebAssembly.Authentication.Auth0/Auth0ProviderOptions.cs
@@ -1,36 +1,57 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Components.WebAssembly.Authentication
 {
+
+    /// <summary>
+    /// Enhances the <see cref="OidcProviderOptions"/> with Auth0-specific configuration.
+    /// </summary>
     public class Auth0ProviderOptions : OidcProviderOptions
     {
+
         private const string AudienceKey = "audience";
 
         /// <summary>
         /// Sets the audience of the application.
         /// </summary>
-        public string? Audience { get; set; }
+        public string Audience
+        {
+            get => AdditionalProviderParameters.ContainsKey(AudienceKey) ? AdditionalProviderParameters[AudienceKey] : "";
+            set => AdditionalProviderParameters[AudienceKey] = value;
+        }
 
         /// <summary>
-        /// Extra Query Parameters
-        /// 
-        /// See https://github.com/IdentityModel/oidc-client-js/blob/dev/src/OidcClient.js#L65
+        /// Gets or sets the additional provider parameters to use on the authorization flow.
         /// </summary>
-        [JsonPropertyName("extraQueryParams")]
+        /// <remarks>
+        /// These parameters are for the IdP and not for the application. Using those parameters in the application in any way on the login callback will likely introduce security issues as they should be treated as untrusted input.
+        /// </remarks>
+        [JsonIgnore]
+        [Obsolete("This property is called 'AdditionalProviderParameters' in OidcProviderOptions on .NET 6.0. For future compatibility, " +
+            "we've left this property as a pointer to the new one. It will be removed in the next major version.", error: false)]
         public IDictionary<string, string> ExtraQueryParams
         {
-            get
-            {
-                var dictionary = new Dictionary<string, string>();
-                if (!string.IsNullOrWhiteSpace(Audience))
-                {
-                    dictionary.Add(AudienceKey, Audience);
-                }
-
-                return dictionary;
-            }
+            get => AdditionalProviderParameters;
         }
+
+#if !NET6_0_OR_GREATER
+
+        /// <summary>
+        /// Gets or sets the additional provider parameters to use on the authorization flow.
+        /// </summary>
+        /// <remarks>
+        /// See https://github.com/IdentityModel/oidc-client-js/blob/dev/src/OidcClient.js#L65.
+        /// This property is already available in .NET 6.0, so we're hiding it on .NET 6 and later so it won't break the deserializer.
+        /// These parameters are for the IdP and not for the application. Using those parameters in the application in any way on the login callback will likely introduce security issues as they should be treated as untrusted input.
+        /// </remarks>
+        [JsonPropertyName("extraQueryParams")]
+        public IDictionary<string, string> AdditionalProviderParameters { get; set; } = new Dictionary<string, string>();
+
+#endif
+
     }
+
 }

--- a/src/Blazor.WebAssembly.Authentication.Auth0/Blazor.WebAssembly.Authentication.Auth0.csproj
+++ b/src/Blazor.WebAssembly.Authentication.Auth0/Blazor.WebAssembly.Authentication.Auth0.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>1.0.1</Version>
+		<Version>1.1.0</Version>
 		<Description>Authenticate your Blazor WebAssembly applications with Auth0</Description>
 		<Authors>Stef Heyenrath</Authors>
-		<TargetFrameworks>netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
 		<PackageId>WebAssembly.Authentication.Auth0</PackageId>
 		<LangVersion>8.0</LangVersion>
 		<Nullable>enable</Nullable>
@@ -26,11 +26,9 @@
 		<None Include="../../resources/icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="3.2.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.0" />
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[3.2.0, 4.0.0)" Condition=" '$(TargetFramework)' == 'netstandard2.1' " />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[5.0.0, 6.0.0)" Condition=" '$(TargetFramework)' == 'net5.0' " />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[6.0.0-rc.1.*, 7.0.0)" Condition=" '$(TargetFramework)' == 'net6.0' "/>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
- Updated Auth0ProviderOptions to provide compatibility with .NET 6 and later without breaking .NET 5 and earlier.
- Added documentation comments based on the .NET 6.0 code.
- Updated the solution to better target specific platforms for compatibility.