### PR TITLE
Update Blazor.WebAssembly.Authentication.Auth0.csproj to support .NET 7

### DIFF
--- a/src/Blazor.WebAssembly.Authentication.Auth0/Blazor.WebAssembly.Authentication.Auth0.csproj
+++ b/src/Blazor.WebAssembly.Authentication.Auth0/Blazor.WebAssembly.Authentication.Auth0.csproj
@@ -31,7 +31,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[3.2.0, 4.0.0)" Condition=" '$(TargetFramework)' == 'netstandard2.1' " />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[5.0.0, 6.0.0)" Condition=" '$(TargetFramework)' == 'net5.0' " />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[6.0.0-rc.1.*, 7.0.0)" Condition=" '$(TargetFramework)' == 'net6.0' "/>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[6.0.0, 7.0.0)" Condition=" '$(TargetFramework)' == 'net6.0' "/>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="[7.0.0, 8.0.0)" Condition=" '$(TargetFramework)' == 'net7.0' "/>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
.NET 5.0 is no longer supported by Microsoft.
Adding .NET 7.0 support.

Fixes #9 